### PR TITLE
Update middleware.py to be compatible with new django versions

### DIFF
--- a/x_forwarded_for/middleware.py
+++ b/x_forwarded_for/middleware.py
@@ -1,4 +1,6 @@
-class XForwardedForMiddleware():
+from django.utils.deprecation import MiddlewareMixin
+
+class XForwardedForMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if 'HTTP_X_FORWARDED_FOR' in request.META:
             request.META['REMOTE_ADDR'] = request.META['HTTP_X_FORWARDED_FOR'].split(",")[0].strip()


### PR DESCRIPTION
Current implementation does not work in django 1.10 upwards because of changes in how middle ware works.

Django supply a mixin to quickly update legacy middleware.